### PR TITLE
Scp trust policy setup

### DIFF
--- a/tests/iam/test_scps.py
+++ b/tests/iam/test_scps.py
@@ -1,0 +1,87 @@
+import botocore
+import boto3
+from conftest import Credentials
+
+"""
+This relies on two hard-coded accounts that have management acccess so that we can both change permissions and test them
+Their trust policies allow for role hopping from the QA account. You might be signed into the QA account for this to work
+"""
+
+
+PARENT_ADMIN_ARN = "arn:aws:iam::745948225562:role/SCPTestMasterAccount"
+CHILD_ADMIN_ARN = "arn:aws:iam::593324772711:role/SCPTestChildSuperRole"
+EXTERNAL_ID = "scps-assume-role-tests"
+# We use hard coded org and ou structure to avoid programmatically creating and tearing down accounts
+# which is not recommended
+OU_ID = "ou-5wjv-glg6vchq"
+FULL_ACCESS_POLICY_ID = "p-FullAWSAccess"
+FULL_ACCESS_POICY_ARN = f"arn:aws:organizations::aws:policy/service_control_policy/{FULL_ACCESS_POLICY_ID}"
+
+def parent_client(service_name):
+    client = boto3.client("sts")
+    credentials = client.assume_role(
+        RoleArn=PARENT_ADMIN_ARN,
+        RoleSessionName="test",
+        ExternalId=EXTERNAL_ID
+    )['Credentials']
+
+    return boto3.client(
+        service_name,
+        aws_access_key_id=credentials['AccessKeyId'],
+        aws_secret_access_key=credentials['SecretAccessKey'],
+        aws_session_token=credentials['SessionToken'],
+    )
+
+def child_superclient(service_name):
+    client = parent_client("sts")
+    credentials = client.assume_role(
+        RoleArn=CHILD_ADMIN_ARN,
+        RoleSessionName="Test",
+        ExternalId=EXTERNAL_ID
+    )["Credentials"]
+
+    return boto3.client(
+        service_name=service_name,
+        aws_access_key_id=credentials['AccessKeyId'],
+        aws_secret_access_key=credentials['SecretAccessKey'],
+        aws_session_token=credentials['SessionToken'],
+    )
+
+# Create the scp that will limit the target role after superchild role creates and alters its permissions
+def reset_scps():
+    client = parent_client("organizations")
+    # Start with baseline of only full access
+    client.attach_policy(
+        PolicyId=FULL_ACCESS_POLICY_ID,
+        TargetId=OU_ID # OU containing child
+    )
+    scps = client.list_policies_for_target(
+        TargetId=OU_ID,
+        Filter="SERVICE_CONTROL_POLICY"
+    )["Policies"]
+    # Detach anything other than full access scp
+    for scp in scps:
+        if scp["Arn"] == FULL_ACCESS_POICY_ARN:
+            continue
+        else:
+            client.detach_policy(
+                PolicyId=scp["Id"],
+                TargetId=OU_ID
+            )
+
+
+def test_scp_on_target_account_limits_assumed_role_actions():
+    """
+    Does an scp on the target account limit access?
+    """
+    reset_scps()
+
+
+def test_scp_on_source_account():
+    """
+    Does an scp on the account assuming the role have any impact?
+    """
+    pass
+    
+
+    

--- a/tests/iam/test_scps.py
+++ b/tests/iam/test_scps.py
@@ -1,16 +1,18 @@
-import pytest
+import json
 
-import botocore
 import boto3
-from conftest import Credentials
+import botocore
+import pytest
+from conftest import Credentials, Role
 
 """
 This relies on two hard-coded accounts that have management acccess so that we can both change permissions and test them
 Their trust policies allow for role hopping from the QA account. You might be signed into the QA account for this to work
 """
 
+PARENT_ACCOUNT_ID = "745948225562"
 TARGET_ACCOUNT_ID = "593324772711"
-PARENT_ADMIN_ARN = "arn:aws:iam::745948225562:role/SCPTestMasterAccount"
+PARENT_ADMIN_ARN = f"arn:aws:iam::{PARENT_ACCOUNT_ID}:role/SCPTestMasterAccount"
 CHILD_ADMIN_ARN = f"arn:aws:iam::{TARGET_ACCOUNT_ID}:role/SCPTestChildSuperRole"
 EXTERNAL_ID = "scps-assume-role-tests"
 # We use hard coded org and ou structure to avoid programmatically creating and tearing down accounts
@@ -82,24 +84,110 @@ def reset_scps():
 @pytest.fixture
 def limited_role(request):
     reset_scps()
+    test_name = request.node.name
+    role_name = f"scp_test_role{test_name.split('[')[0]}"
     # assume the child superclient role
-    yield child_superclient("iam")
+    client = child_superclient("iam")
+     # configure the role to be assumable by parent account
+    assume_role_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": PARENT_ACCOUNT_ID},
+                "Action": "sts:AssumeRole",
+            }
+        ]
+    }
+    try:
+        role = client.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(assume_role_policy, indent=2),
+        )['Role']
+    # To avoid collisions with earlier tests that my have been partially run
+    # Delete any roles by the same name that already exist
+    except botocore.exceptions.ClientError as error:
+        if error.response["Error"]["Code"] == "EntityAlreadyExists":
+            client.delete_role(RoleName=role_name)
+            role = client.create_role(
+                RoleName=role_name,
+                AssumeRolePolicyDocument=json.dumps(assume_role_policy, indent=2),
+            )['Role']
+        else:
+            raise error
+
+    yield Role(
+        role_name=role_name,
+        arn=role['Arn'],
+    )
+
+    # Cleanup
+    for policy_name in client.list_role_policies(RoleName=role_name)['PolicyNames']:
+            client.delete_role_policy(
+                RoleName=role_name,
+                PolicyName=policy_name,
+            )
+    client.delete_role(
+        RoleName=role_name,
+    )
 
     reset_scps()
 
+
 # Note the importance of passing limited_role first. Must assume a role in the target account
 # before creating the test role so that the latter is also in the target account
-def test_scp_on_target_account(limited_role, policy_executor):
+def test_scp_on_target_account(limited_role):
     """
     Does an scp on the target account limit access?
     """
-    # Caller account should be the target account after calling limited role
-    assert policy_executor._get_user_account_id() == TARGET_ACCOUNT_ID
-    
+    client = child_superclient("iam")
     # Identity policy that permits something generic
-    idp = {}
+    idp = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "statement1",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:CreateBucket",
+                ],
+                "Resource": "*",
+            }
+        ]
+    }
+    # Attach idp
+    client.put_role_policy(
+        RoleName=limited_role.role_name,
+        PolicyName="AllowCreateBucket",
+        PolicyDocument=json.dumps(idp, indent=2),
+    )
 
+    # Use parent client to switch to limited role
+    client = parent_client("sts")
+    credentials = client.assume_role(
+        RoleArn=limited_role.arn,
+        RoleSessionName="test",
+        ExternalId=EXTERNAL_ID
+    )["Credentials"]
+    client = boto3.client(
+        service_name=service_name,
+        aws_access_key_id=credentials['AccessKeyId'],
+        aws_secret_access_key=credentials['SecretAccessKey'],
+        aws_session_token=credentials['SessionToken'],
+    )
+
+    # attempt action
+    client.create_bucket(
+        Bucket="scp_test_bucket"
+    )
+
+    # Switch to parent role
+    # Create and attach scp to child account
+    # SCP that limits permission to some different generic thing
     scp = {}
+    # Remove allow all scp
+    # Swith to target role
+    # attempt action again
 
     # Should work without scp
 


### PR DESCRIPTION
This test shows the impact of SCPs on trust policies. This one confirmed that implicit denies on the trusting account do apply, even when the role is assumed from another account. 
Next up, testing the impact of implicit denies on the trusted account. 